### PR TITLE
Add Makefile with install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 Xilinx, Inc.
+#
+
+INSTALL_PROGRAM ?= install
+bindir ?= /usr/bin
+
+all:
+
+install:
+	$(INSTALL_PROGRAM) -D -m 755 xmutil $(DESTDIR)$(bindir)/xmutil
+	$(INSTALL_PROGRAM) -D -m 755 som-pwrctl $(DESTDIR)$(bindir)/som-pwrctl
+
+clean:
+


### PR DESCRIPTION
Hi,

This adds a toplevel Makefile with an install target, making downstream packaging a tad easier.

Best,
Loïc Minier